### PR TITLE
updated data selector algorithm to tokenizer/parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 lib/
 node_modules/
+coverage/

--- a/src/RuleTreeBuilder.js
+++ b/src/RuleTreeBuilder.js
@@ -1,10 +1,12 @@
 import { RuleTree } from './RuleTree';
 import { DataSelector } from './selectors/DataSelector';
+import { Parser } from "./selectors/parser/Parser";
+import { Tokenizer } from "./selectors/tokenizer/Tokenizer";
 
 export class RuleTreeBuilder {
     constructor() {
         this.options = {
-            dataSelector: new DataSelector(),
+            dataSelector: new DataSelector(new Parser(new Tokenizer())),
             validators: {},
             parsers: {}
         };

--- a/src/selectors/DataSelector.js
+++ b/src/selectors/DataSelector.js
@@ -16,16 +16,24 @@ export class DataSelector {
         }, data);
     }
 
-    selectProperty(data, entry, selector) {
+    selectEntry(data, entry, selector, getter) {
         if (entry.modifier && entry.modifier.type === 'flat-map-modifier') {
             if (!Array.isArray(data)) {
                 throw new SyntaxError(`Data is not an array for flat map property (${selector.substring(entry.start, entry.end)})`);
             }
 
-            return this.reduceData(data, entry, selector, this.getProperty.bind(this));
+            return this.reduceData(data, entry, selector, getter);
         }
 
-        return this.getProperty(data, entry, selector);
+        return getter(data, entry, selector);
+    }
+
+    selectProperty(data, entry, selector) {
+        return this.selectEntry(data, entry, selector, this.getProperty.bind(this));
+    }
+
+    selectMethod(data, entry, selector) {
+        return this.selectEntry(data, entry, selector, this.getMethod.bind(this));
     }
 
     getProperty(data, entry, selector) {
@@ -36,18 +44,6 @@ export class DataSelector {
         }
 
         throw new SyntaxError(`No property "${path}" in data (${selector.substring(entry.start, entry.end)})`);
-    }
-
-    selectMethod(data, entry, selector) {
-        if (entry.modifier && entry.modifier.type === 'flat-map-modifier') {
-            if (!Array.isArray(data)) {
-                throw new SyntaxError(`Data is not an array for flat map property (${selector.substring(entry.start, entry.end)})`);
-            }
-
-            return this.reduceData(data, entry, selector, this.getMethod.bind(this));
-        }
-
-        return this.getMethod(data, entry, selector);
     }
 
     getMethod(data, entry, selector) {

--- a/src/selectors/DataSelector.js
+++ b/src/selectors/DataSelector.js
@@ -1,88 +1,189 @@
 
-const SELECTOR_REGEX = /(([.#]?)(\w+)(\[])?)/g;
-
 export class DataSelector {
     select(data, selector) {
-        let dataSelector = selector;
+        if (!selector) return data;
 
-        if (!dataSelector) {
-            return data;
-        }
+        const context = { pos: 0, selector };
+        const node = this.parseSelection(context);
 
-        if (!this.isPropertyAccessor(selector[0]) && !this.isMethodAccessor(selector[0])) {
-            dataSelector = '.' + dataSelector;
-        }
-
-        const matches = this.getMatches(dataSelector);
-        const parentMatch = ['root'];
-
-        if (!matches.length) {
-            throw new SyntaxError(`Wrong selector syntax in "${selector}"`);
-        }
-        
-        return matches.reduce((data, match) => {
-            const [cmd, accessor, path, modifier] = match.slice(1);
-            const absolutePath = parentMatch.join('');
-            
-            parentMatch.push(`${accessor}${path}${modifier || ''}`);
-            
-            if (this.isPropertyAccessor(accessor)) return this.getProperty(data, path, absolutePath, modifier);
-            if (this.isMethodAccessor(accessor)) return this.getMethod(data, path, absolutePath, modifier);
-
-            // TODO: fix regex matcher to match from start of string
-            throw new SyntaxError(`Wrong selector syntax in "${cmd}"`);
+        return node.entries.reduce((data, entry) => {
+            if (entry.type === 'property') return this.selectProperty(data, entry, selector);
+            if (entry.type === 'method') return this.selectMethod(data, entry, selector);
+            throw new SyntaxError(`Wrong selector syntax in "${selector.substring(entry.start, entry.end)}"`);
         }, data);
     }
-    
-    isPropertyAccessor(accessor) {
-        return accessor === '.';
-    }
-    
-    isMethodAccessor(accessor) {
-        return accessor === '#';
-    }
 
-    isFlatMapModifier(modifier) {
-        return modifier === '[]'
-    }
-    
-    getProperty(data, path, absolutePath, modifier) {
-        if (this.isFlatMapModifier(modifier)) {
+    selectProperty(data, entry, selector) {
+        if (entry.modifier && entry.modifier.type === 'flat-map-modifier') {
             if (!Array.isArray(data)) {
-                throw new SyntaxError(`Data is not an array for flat map property (${absolutePath})`);
+                throw new SyntaxError(`Data is not an array for flat map property (${selector.substring(entry.start, entry.end)})`);
             }
 
-            return this.reduceData(data, path, absolutePath, this.getProperty.bind(this));
+            return this.reduceData(data, entry, selector, this.getProperty.bind(this));
         }
-        if (!(path in data)) throw new SyntaxError(`No property "${path}" in data (${absolutePath})`);
-        return data[path];
+
+        return this.getProperty(data, entry, selector);
     }
-    
-    getMethod(data, path, absolutePath, modifier) {
-        if (this.isFlatMapModifier(modifier)) {
+
+    getProperty(data, entry, selector) {
+        const { value: path } = entry;
+
+        if (path in data) {
+            return data[path];
+        }
+
+        throw new SyntaxError(`No property "${path}" in data (${selector.substring(entry.start, entry.end)})`);
+    }
+
+    selectMethod(data, entry, selector) {
+        if (entry.modifier && entry.modifier.type === 'flat-map-modifier') {
             if (!Array.isArray(data)) {
-                throw new SyntaxError(`Data is not an array for flat map property (${absolutePath})`);
+                throw new SyntaxError(`Data is not an array for flat map property (${selector.substring(entry.start, entry.end)})`);
             }
 
-            return this.reduceData(data, path, absolutePath, this.getMethod.bind(this));
+            return this.reduceData(data, entry, selector, this.getMethod.bind(this));
         }
-        if (!(path in data)) throw new SyntaxError(`No method "${path}" in data (${absolutePath})`);
-        if (typeof data[path] !== 'function') throw new SyntaxError(`Property "${path}" is not a function (${absolutePath})`);
-        return data[path]();
+
+        return this.getMethod(data, entry, selector);
     }
 
-    reduceData(data, path, absolutePath, reducer) {
-        return data.reduce((arr, item) => arr.concat(reducer(item, path, absolutePath)), []);
-    }
-    
-    getMatches(selector) {
-        const matches = [];
-        let match;
-        
-        while ((match = SELECTOR_REGEX.exec(selector)) !== null) {
-            matches.push(match);
+    getMethod(data, entry, selector) {
+        const { value: path } = entry;
+
+        if (path in data) {
+            if (typeof data[path] === 'function') {
+                return data[path]();
+            }
+
+            throw new SyntaxError(`Property "${path}" is not a function (${selector.substring(entry.start, entry.end)})`);
         }
-        
-        return matches;
+
+        throw new SyntaxError(`No method "${path}" in data (${selector.substring(entry.start, entry.end)})`);
+    }
+
+    reduceData(data, entry, selector, reducer) {
+        return data.reduce((arr, item) => arr.concat(reducer(item, entry, selector)), []);
+    }
+
+    parseSelection(context) {
+        const len = context.selector.length;
+        const entries = [];
+
+        while (context.pos < len) {
+            entries.push(this.parseIdentifierWithAccessor(context));
+        }
+
+        return { type: 'selection', entries };
+    }
+
+    parseIdentifierWithAccessor(context) {
+        const accessor = this.nextToken(context);
+
+        if (accessor.type === 'property' || accessor.type === 'method') {
+            this.consumeToken(context);
+            return this.parseIdentifier(context, accessor);
+        } else if (accessor.type === 'identifier') {
+            return this.parseIdentifier(context, { type: 'property', start: accessor.start, end: accessor.start });
+        }
+
+        this.raiseException(context, accessor.start);
+    }
+
+    parseIdentifier(context, accessor) {
+        const identifier = this.consumeToken(context);
+
+        if (identifier.type === 'identifier') {
+            const modifier = this.parseModifier(context);
+            return {
+                type: accessor.type,
+                value: identifier.value,
+                modifier,
+                start: accessor.start,
+                end: modifier ? modifier.end : identifier.end
+            };
+        }
+
+        this.raiseException(context, identifier.start);
+    }
+
+    parseModifier(context) {
+        const modifierStart = this.nextToken(context);
+
+        if (modifierStart.type === 'bracket-start') {
+            const modifierEnd = this.consumeAndNextToken(context);
+
+            if (modifierEnd.type === 'bracket-end') {
+                this.consumeToken(context);
+                return { type: 'flat-map-modifier' };
+            }
+
+            this.raiseException(context, modifierEnd.start);
+        }
+
+        return null;
+    }
+
+    raiseException(context, position) {
+        throw new Error(`Unexpected token "${context.selector.charAt(position)}" at position "${position}"`);
+    }
+
+    isIdentifierChar(char) {
+        return (char >= 'a' && char <= 'z') ||
+            (char >= 'A' && char <= 'Z') ||
+            (char >= '0' && char <= '9');
+    }
+
+    consumeToken(context) {
+        const token = this.nextToken(context);
+        context.pos = token.end;
+        return token;
+    }
+
+    nextToken(context) {
+        const { pos, selector } = context;
+
+        return pos < selector.length
+            ? this.parseToken(context, selector.charAt(pos))
+            : { type: 'eof', start: pos, end: pos };
+    }
+
+    consumeAndNextToken(context) {
+        this.consumeToken(context);
+        return this.nextToken(context);
+    }
+
+    parseToken(context, char) {
+        switch (char) {
+            case '.': return { type: 'property', start: context.pos, end: context.pos + 1 };
+            case '#': return { type: 'method', start: context.pos, end: context.pos + 1 };
+            case '[': return { type: 'bracket-start', start: context.pos, end: context.pos + 1 };
+            case ']': return { type: 'bracket-end', start: context.pos, end: context.pos + 1 };
+            default:
+                if (this.isIdentifierChar(char)) return this.parseIdentifierToken(context);
+                throw new Error(`Unexpected token "${char}" at position "${context.pos}"`);
+        }
+    }
+
+    parseIdentifierToken(context) {
+        let pos = context.pos;
+        let selector = context.selector;
+        let len = selector.length;
+
+        while (pos < len) {
+            const char = selector.charAt(pos);
+
+            if (!this.isIdentifierChar(char)) {
+                break;
+            }
+
+            pos++;
+        }
+
+        return {
+            type: 'identifier',
+            value: context.selector.substring(context.pos, pos),
+            start: context.pos,
+            end: pos
+        };
     }
 }

--- a/src/selectors/DataSelector.js
+++ b/src/selectors/DataSelector.js
@@ -1,10 +1,13 @@
 
 export class DataSelector {
+    constructor(parser) {
+        this.parser = parser;
+    }
+
     select(data, selector) {
         if (!selector) return data;
 
-        const context = { pos: 0, selector };
-        const node = this.parseSelection(context);
+        const node = this.parser.parse(selector);
 
         return node.entries.reduce((data, entry) => {
             if (entry.type === 'property') return this.selectProperty(data, entry, selector);
@@ -63,127 +66,5 @@ export class DataSelector {
 
     reduceData(data, entry, selector, reducer) {
         return data.reduce((arr, item) => arr.concat(reducer(item, entry, selector)), []);
-    }
-
-    parseSelection(context) {
-        const len = context.selector.length;
-        const entries = [];
-
-        while (context.pos < len) {
-            entries.push(this.parseIdentifierWithAccessor(context));
-        }
-
-        return { type: 'selection', entries };
-    }
-
-    parseIdentifierWithAccessor(context) {
-        const accessor = this.nextToken(context);
-
-        if (accessor.type === 'property' || accessor.type === 'method') {
-            this.consumeToken(context);
-            return this.parseIdentifier(context, accessor);
-        } else if (accessor.type === 'identifier') {
-            return this.parseIdentifier(context, { type: 'property', start: accessor.start, end: accessor.start });
-        }
-
-        this.raiseException(context, accessor.start);
-    }
-
-    parseIdentifier(context, accessor) {
-        const identifier = this.consumeToken(context);
-
-        if (identifier.type === 'identifier') {
-            const modifier = this.parseModifier(context);
-            return {
-                type: accessor.type,
-                value: identifier.value,
-                modifier,
-                start: accessor.start,
-                end: modifier ? modifier.end : identifier.end
-            };
-        }
-
-        this.raiseException(context, identifier.start);
-    }
-
-    parseModifier(context) {
-        const modifierStart = this.nextToken(context);
-
-        if (modifierStart.type === 'bracket-start') {
-            const modifierEnd = this.consumeAndNextToken(context);
-
-            if (modifierEnd.type === 'bracket-end') {
-                this.consumeToken(context);
-                return { type: 'flat-map-modifier' };
-            }
-
-            this.raiseException(context, modifierEnd.start);
-        }
-
-        return null;
-    }
-
-    raiseException(context, position) {
-        throw new Error(`Unexpected token "${context.selector.charAt(position)}" at position "${position}"`);
-    }
-
-    isIdentifierChar(char) {
-        return (char >= 'a' && char <= 'z') ||
-            (char >= 'A' && char <= 'Z') ||
-            (char >= '0' && char <= '9');
-    }
-
-    consumeToken(context) {
-        const token = this.nextToken(context);
-        context.pos = token.end;
-        return token;
-    }
-
-    nextToken(context) {
-        const { pos, selector } = context;
-
-        return pos < selector.length
-            ? this.parseToken(context, selector.charAt(pos))
-            : { type: 'eof', start: pos, end: pos };
-    }
-
-    consumeAndNextToken(context) {
-        this.consumeToken(context);
-        return this.nextToken(context);
-    }
-
-    parseToken(context, char) {
-        switch (char) {
-            case '.': return { type: 'property', start: context.pos, end: context.pos + 1 };
-            case '#': return { type: 'method', start: context.pos, end: context.pos + 1 };
-            case '[': return { type: 'bracket-start', start: context.pos, end: context.pos + 1 };
-            case ']': return { type: 'bracket-end', start: context.pos, end: context.pos + 1 };
-            default:
-                if (this.isIdentifierChar(char)) return this.parseIdentifierToken(context);
-                throw new Error(`Unexpected token "${char}" at position "${context.pos}"`);
-        }
-    }
-
-    parseIdentifierToken(context) {
-        let pos = context.pos;
-        let selector = context.selector;
-        let len = selector.length;
-
-        while (pos < len) {
-            const char = selector.charAt(pos);
-
-            if (!this.isIdentifierChar(char)) {
-                break;
-            }
-
-            pos++;
-        }
-
-        return {
-            type: 'identifier',
-            value: context.selector.substring(context.pos, pos),
-            start: context.pos,
-            end: pos
-        };
     }
 }

--- a/src/selectors/parser/Parser.js
+++ b/src/selectors/parser/Parser.js
@@ -1,0 +1,71 @@
+
+export class Parser {
+    constructor(tokenizer) {
+        this.tokenizer = tokenizer;
+    }
+
+    parse(selector) {
+        this.tokenizer.setSelector(selector);
+
+        const len = this.tokenizer.context.selector.length;
+        const entries = [];
+
+        while (this.tokenizer.context.pos < len) {
+            entries.push(this.parseIdentifierWithAccessor());
+        }
+
+        return { type: 'selection', entries };
+    }
+
+    parseIdentifierWithAccessor() {
+        const accessor = this.tokenizer.nextToken();
+
+        if (accessor.type === 'property' || accessor.type === 'method') {
+            this.tokenizer.consumeToken();
+            return this.parseIdentifier(accessor);
+        } else if (accessor.type === 'identifier') {
+            return this.parseIdentifier({ type: 'property', start: accessor.start, end: accessor.start });
+        }
+
+        this.raiseException(accessor);
+    }
+
+    parseIdentifier(accessor) {
+        const identifier = this.tokenizer.consumeToken();
+
+        if (identifier.type === 'identifier') {
+            const modifier = this.parseModifier();
+            return {
+                type: accessor.type,
+                value: identifier.value,
+                modifier,
+                start: accessor.start,
+                end: modifier ? modifier.end : identifier.end
+            };
+        }
+
+        this.raiseException(identifier);
+    }
+
+    parseModifier() {
+        const modifierStart = this.tokenizer.nextToken();
+
+        if (modifierStart.type === 'bracket-start') {
+            const modifierEnd = this.tokenizer.consumeAndNextToken();
+
+            if (modifierEnd.type === 'bracket-end') {
+                this.tokenizer.consumeToken();
+                return { type: 'flat-map-modifier' };
+            }
+
+            this.raiseException(modifierEnd);
+        }
+
+        return null;
+    }
+
+    raiseException(token) {
+        const tokenStr = this.tokenizer.context.selector.substring(token.start, token.end);
+        throw new Error(`Unexpected token "${tokenStr}" at position "${token.start}"`);
+    }
+}

--- a/src/selectors/tokenizer/Tokenizer.js
+++ b/src/selectors/tokenizer/Tokenizer.js
@@ -1,43 +1,39 @@
 
 export class Tokenizer {
-    setSelector(selector) {
-        this.context = { pos: 0, selector };
-    }
-
-    consumeToken() {
-        const token = this.nextToken();
-        this.context.pos = token.end;
+    consumeToken(context) {
+        const token = this.nextToken(context);
+        context.pos = token.end;
         return token;
     }
 
-    nextToken() {
-        const { pos, selector } = this.context;
+    nextToken(context) {
+        const { pos, selector } = context;
 
         return pos < selector.length
-            ? this.parseToken(selector.charAt(pos))
+            ? this.parseToken(context, selector.charAt(pos))
             : { type: 'eof', start: pos, end: pos };
     }
 
-    consumeAndNextToken() {
-        this.consumeToken();
-        return this.nextToken();
+    consumeAndNextToken(context) {
+        this.consumeToken(context);
+        return this.nextToken(context);
     }
 
-    parseToken(char) {
+    parseToken(context, char) {
         switch (char) {
-            case '.': return { type: 'property', start: this.context.pos, end: this.context.pos + 1 };
-            case '#': return { type: 'method', start: this.context.pos, end: this.context.pos + 1 };
-            case '[': return { type: 'bracket-start', start: this.context.pos, end: this.context.pos + 1 };
-            case ']': return { type: 'bracket-end', start: this.context.pos, end: this.context.pos + 1 };
+            case '.': return { type: 'property', start: context.pos, end: context.pos + 1 };
+            case '#': return { type: 'method', start: context.pos, end: context.pos + 1 };
+            case '[': return { type: 'bracket-start', start: context.pos, end: context.pos + 1 };
+            case ']': return { type: 'bracket-end', start: context.pos, end: context.pos + 1 };
             default:
-                if (this.isIdentifierChar(char)) return this.parseIdentifierToken();
-                this.raiseException(char, this.context.pos);
+                if (this.isIdentifierChar(char)) return this.parseIdentifierToken(context);
+                this.raiseException(char, context.pos);
         }
     }
 
-    parseIdentifierToken() {
-        let pos = this.context.pos;
-        let selector = this.context.selector;
+    parseIdentifierToken(context) {
+        let pos = context.pos;
+        let selector = context.selector;
         let len = selector.length;
 
         while (pos < len) {
@@ -52,8 +48,8 @@ export class Tokenizer {
 
         return {
             type: 'identifier',
-            value: this.context.selector.substring(this.context.pos, pos),
-            start: this.context.pos,
+            value: context.selector.substring(context.pos, pos),
+            start: context.pos,
             end: pos
         };
     }

--- a/src/selectors/tokenizer/Tokenizer.js
+++ b/src/selectors/tokenizer/Tokenizer.js
@@ -1,0 +1,70 @@
+
+export class Tokenizer {
+    setSelector(selector) {
+        this.context = { pos: 0, selector };
+    }
+
+    consumeToken() {
+        const token = this.nextToken();
+        this.context.pos = token.end;
+        return token;
+    }
+
+    nextToken() {
+        const { pos, selector } = this.context;
+
+        return pos < selector.length
+            ? this.parseToken(selector.charAt(pos))
+            : { type: 'eof', start: pos, end: pos };
+    }
+
+    consumeAndNextToken() {
+        this.consumeToken();
+        return this.nextToken();
+    }
+
+    parseToken(char) {
+        switch (char) {
+            case '.': return { type: 'property', start: this.context.pos, end: this.context.pos + 1 };
+            case '#': return { type: 'method', start: this.context.pos, end: this.context.pos + 1 };
+            case '[': return { type: 'bracket-start', start: this.context.pos, end: this.context.pos + 1 };
+            case ']': return { type: 'bracket-end', start: this.context.pos, end: this.context.pos + 1 };
+            default:
+                if (this.isIdentifierChar(char)) return this.parseIdentifierToken();
+                this.raiseException(char, this.context.pos);
+        }
+    }
+
+    parseIdentifierToken() {
+        let pos = this.context.pos;
+        let selector = this.context.selector;
+        let len = selector.length;
+
+        while (pos < len) {
+            const char = selector.charAt(pos);
+
+            if (!this.isIdentifierChar(char)) {
+                break;
+            }
+
+            pos++;
+        }
+
+        return {
+            type: 'identifier',
+            value: this.context.selector.substring(this.context.pos, pos),
+            start: this.context.pos,
+            end: pos
+        };
+    }
+
+    isIdentifierChar(char) {
+        return (char >= 'a' && char <= 'z') ||
+            (char >= 'A' && char <= 'Z') ||
+            (char >= '0' && char <= '9');
+    }
+
+    raiseException(char, position) {
+        throw new Error(`Unexpected token "${char}" at position "${position}"`);
+    }
+}

--- a/src/selectors/tokenizer/TokenizerContext.js
+++ b/src/selectors/tokenizer/TokenizerContext.js
@@ -1,0 +1,7 @@
+
+export class TokenizerContext {
+    constructor(selector) {
+        this.pos = 0;
+        this.selector = selector;
+    }
+}

--- a/test/selectors/DataSelector.spec.js
+++ b/test/selectors/DataSelector.spec.js
@@ -12,15 +12,13 @@ describe('DataSelector', () => {
         it('throws a SyntaxError when selector syntax has no matches', () => {
             const selector = new DataSelector();
 
-            expect(() => selector.select({}, '???')).toThrow(SyntaxError);
-            expect(() => selector.select({}, '???')).toThrow('Wrong selector syntax in "???"');
+            expect(() => selector.select({}, '???')).toThrow('Unexpected token "?" at position "0"');
         });
 
-        it.skip('throws a SyntaxError when selector syntax is invalid', () => {
+        it('throws a SyntaxError when selector syntax is invalid', () => {
             const selector = new DataSelector();
 
-            expect(() => selector.select({}, '?prop')).toThrow(SyntaxError);
-            expect(() => selector.select({}, '?prop')).toThrow('Wrong selector syntax in "?prop"');
+            expect(() => selector.select({}, '?prop')).toThrow('Unexpected token "?" at position "0"');
         });
 
         describe('property accessors', () => {
@@ -55,8 +53,7 @@ describe('DataSelector', () => {
                 const data = { prop: 1 };
                 const selector = new DataSelector();
 
-                expect(() => selector.select(data, '.prop[]')).toThrow(SyntaxError);
-                expect(() => selector.select(data, '.prop[]')).toThrow('Data is not an array for flat map property (root)');
+                expect(() => selector.select(data, '.prop[]')).toThrow('Data is not an array for flat map property (.prop[])');
             });
         });
 
@@ -79,6 +76,20 @@ describe('DataSelector', () => {
                 expect(selector.select(data, '#prop1#prop2#prop3')).toBe(value);
             });
 
+            it('throws a SyntaxError when no property for selector exists', () => {
+                const data = { prop2: 1 };
+                const selector = new DataSelector();
+
+                expect(() => selector.select(data, '#prop')).toThrow('No method "prop" in data (#prop)');
+            });
+
+            it('throws a SyntaxError when property for selector is not a function', () => {
+                const data = { prop: 1 };
+                const selector = new DataSelector();
+
+                expect(() => selector.select(data, '#prop')).toThrow('Property "prop" is not a function (#prop)');
+            });
+
             it('accepts a flatMap modifier', () => {
                 const data = [ { value: () => 1 }, { value: () => 2 }, { value: () => 3 } ];
                 const value = [1, 2, 3];
@@ -92,8 +103,7 @@ describe('DataSelector', () => {
                 const data = { prop: () => 1 };
                 const selector = new DataSelector();
 
-                expect(() => selector.select(data, '#prop[]')).toThrow(SyntaxError);
-                expect(() => selector.select(data, '#prop[]')).toThrow('Data is not an array for flat map property (root)');
+                expect(() => selector.select(data, '#prop[]')).toThrow('Data is not an array for flat map property (#prop[])');
             });
         });
 

--- a/test/selectors/DataSelector.spec.js
+++ b/test/selectors/DataSelector.spec.js
@@ -1,22 +1,24 @@
 import { DataSelector } from "../../src/selectors/DataSelector";
+import { Tokenizer } from "../../src/selectors/tokenizer/Tokenizer";
+import { Parser } from "../../src/selectors/parser/Parser";
 
 describe('DataSelector', () => {
     describe('#select', () => {
         it('returns data when no selector is passed', () => {
             const data = {};
-            const selector = new DataSelector();
+            const selector = new DataSelector(new Parser(new Tokenizer()));
 
             expect(selector.select(data)).toBe(data);
         });
 
         it('throws a SyntaxError when selector syntax has no matches', () => {
-            const selector = new DataSelector();
+            const selector = new DataSelector(new Parser(new Tokenizer()));
 
             expect(() => selector.select({}, '???')).toThrow('Unexpected token "?" at position "0"');
         });
 
         it('throws a SyntaxError when selector syntax is invalid', () => {
-            const selector = new DataSelector();
+            const selector = new DataSelector(new Parser(new Tokenizer()));
 
             expect(() => selector.select({}, '?prop')).toThrow('Unexpected token "?" at position "0"');
         });
@@ -26,7 +28,7 @@ describe('DataSelector', () => {
                 const data = { prop: 'value' };
                 const value = data.prop;
 
-                const selector = new DataSelector();
+                const selector = new DataSelector(new Parser(new Tokenizer()));
 
                 expect(selector.select(data, '.prop')).toBe(value);
             });
@@ -35,7 +37,7 @@ describe('DataSelector', () => {
                 const data = { prop1: { prop2: { prop3: 'value' } } };
                 const value = data.prop1.prop2.prop3;
 
-                const selector = new DataSelector();
+                const selector = new DataSelector(new Parser(new Tokenizer()));
 
                 expect(selector.select(data, '.prop1.prop2.prop3')).toBe(value);
             });
@@ -44,14 +46,14 @@ describe('DataSelector', () => {
                 const data = [ { value: 1 }, { value: 2 }, { value: 3 } ];
                 const value = [1, 2, 3];
 
-                const selector = new DataSelector();
+                const selector = new DataSelector(new Parser(new Tokenizer()));
 
                 expect(selector.select(data, '.value[]')).toEqual(value);
             });
 
             it('throws a SyntaxError when data selected with flatMap is not an array', () => {
                 const data = { prop: 1 };
-                const selector = new DataSelector();
+                const selector = new DataSelector(new Parser(new Tokenizer()));
 
                 expect(() => selector.select(data, '.prop[]')).toThrow('Data is not an array for flat map property (.prop[])');
             });
@@ -62,7 +64,7 @@ describe('DataSelector', () => {
                 const data = { prop: () => 'value' };
                 const value = data.prop();
 
-                const selector = new DataSelector();
+                const selector = new DataSelector(new Parser(new Tokenizer()));
 
                 expect(selector.select(data, '#prop')).toBe(value);
             });
@@ -71,21 +73,21 @@ describe('DataSelector', () => {
                 const data = { prop1: () => ({ prop2: () => ({ prop3: () => 'value' }) }) };
                 const value = data.prop1().prop2().prop3();
 
-                const selector = new DataSelector();
+                const selector = new DataSelector(new Parser(new Tokenizer()));
 
                 expect(selector.select(data, '#prop1#prop2#prop3')).toBe(value);
             });
 
             it('throws a SyntaxError when no property for selector exists', () => {
                 const data = { prop2: 1 };
-                const selector = new DataSelector();
+                const selector = new DataSelector(new Parser(new Tokenizer()));
 
                 expect(() => selector.select(data, '#prop')).toThrow('No method "prop" in data (#prop)');
             });
 
             it('throws a SyntaxError when property for selector is not a function', () => {
                 const data = { prop: 1 };
-                const selector = new DataSelector();
+                const selector = new DataSelector(new Parser(new Tokenizer()));
 
                 expect(() => selector.select(data, '#prop')).toThrow('Property "prop" is not a function (#prop)');
             });
@@ -94,14 +96,14 @@ describe('DataSelector', () => {
                 const data = [ { value: () => 1 }, { value: () => 2 }, { value: () => 3 } ];
                 const value = [1, 2, 3];
 
-                const selector = new DataSelector();
+                const selector = new DataSelector(new Parser(new Tokenizer()));
 
                 expect(selector.select(data, '#value[]')).toEqual(value);
             });
 
             it('throws a SyntaxError when data selected with flatMap is not an array', () => {
                 const data = { prop: () => 1 };
-                const selector = new DataSelector();
+                const selector = new DataSelector(new Parser(new Tokenizer()));
 
                 expect(() => selector.select(data, '#prop[]')).toThrow('Data is not an array for flat map property (#prop[])');
             });
@@ -112,7 +114,7 @@ describe('DataSelector', () => {
                 const data = { prop1: { prop2: { prop3: () => 'value' } } };
                 const value = data.prop1.prop2.prop3();
 
-                const selector = new DataSelector();
+                const selector = new DataSelector(new Parser(new Tokenizer()));
 
                 expect(selector.select(data, 'prop1.prop2#prop3')).toBe(value);
             });

--- a/test/selectors/DataSelector.spec.js
+++ b/test/selectors/DataSelector.spec.js
@@ -4,7 +4,7 @@ import { Parser } from "../../src/selectors/parser/Parser";
 
 describe('DataSelector', () => {
     describe('#select', () => {
-        it('returns data when no selector is passed', () => {
+        it('returns data when no selector is present', () => {
             const data = {};
             const selector = new DataSelector(new Parser(new Tokenizer()));
 


### PR DESCRIPTION
Using RegExp patterns, rule-tree have limited possibilities for data selector customization and validation. In this PR, a simple tokenizer/parser and new data selector is being implemented. In future, it will enable accessor/modifier customization and other syntax for data selector.

- [x] Implement tokenizer with accessors, identifers and modifiers
- [x] Implement parser with accessors, identifers and modifiers
- [x] Implement selector using structure from parser
- [x] Refactor DataSelector into Tokenizer, Parser and Selector